### PR TITLE
add session recording

### DIFF
--- a/bin/aimes-emgr-rest
+++ b/bin/aimes-emgr-rest
@@ -235,12 +235,12 @@ def _run_workload(ssid):
             # run the workload, and also pass the state callback so that we get
             # state notifications
             sid = aimes.emgr.execute_swift_workload(cfg, run, sw, _state_cb)
-            with open("%s/session_ids.txt" % data, "a") as f:
+            with open("%s/%s/session_ids.txt" % (data, ssid), "a") as f:
                 f.write("%s\n" % sid)
-            mkdir("%s/%s/" % (data, sid))
-            ru.write_json(run,  "%s/%s/run.json"  % (data, sid))
-            ru.write_json(cfg,  "%s/%s/cfg.json"  % (data, sid))
-            ru.write_json(work, "%s/%s/work.json" % (data, sid))
+            mkdir("%s/%s/%s/" % (data, ssid, sid))
+            ru.write_json(run,  "%s/%s/%s/run.json"  % (data, ssid, sid))
+            ru.write_json(cfg,  "%s/%s/%s/cfg.json"  % (data, ssid, sid))
+            ru.write_json(work, "%s/%s/%s/work.json" % (data, ssid, sid))
 
         wl_thread = threading.Thread(target=_wl_executor, args=[cfg, run, sw])
         wl_thread.start()

--- a/bin/aimes-emgr-rest
+++ b/bin/aimes-emgr-rest
@@ -235,12 +235,12 @@ def _run_workload(emgr_sid):
             # run the workload, and also pass the state callback so that we get
             # state notifications
             rp_sid = aimes.emgr.execute_swift_workload(cfg, run, sw, _state_cb)
-            with open("%s/%s/session_ids.txt" % (data, emgr_sid), "a") as f:
-                f.write("%s\n" % rp_sid)
+
             mkdir("%s/%s/%s/" % (data, emgr_sid, rp_sid))
             ru.write_json(run,  "%s/%s/%s/run.json"  % (data, emgr_sid, rp_sid))
             ru.write_json(cfg,  "%s/%s/%s/cfg.json"  % (data, emgr_sid, rp_sid))
-            ru.write_json(work, "%s/%s/%s/work.json" % (data, emgr_sid, rp_sid))
+            with open("%s/%s/session_ids.txt" % (data, emgr_sid), "a+") as f:
+                f.write("%s\n" % rp_sid)
 
         wl_thread = threading.Thread(target=_wl_executor, args=[cfg, run, sw])
         wl_thread.start()

--- a/bin/aimes-emgr-rest
+++ b/bin/aimes-emgr-rest
@@ -20,15 +20,15 @@ import radical.utils as ru
 #
 # The API is basically:
 #
-#   ssid = create_swift_session()
-#   stid = submit_swift_task(ssid, description)
-#   state = check_state(ssid, stid)
+#   emgr_sid = create_swift_session()
+#   emgr_tid = submit_swift_task(emgr_sid, description)
+#   state    = check_state(emgr_sid, emgr_tid)
 #
 # On disk, we basically have this layout:
 #
 #   -- root/
 #      |
-#      +-- ssid/
+#      +-- emgr_sid/
 #          |
 #          + -- timestamp   # time of last workload execution
 #          + -- workload_01/
@@ -93,19 +93,19 @@ def link(path, src, tgt):
 # update timestamps for workloads.  See documentation of _workload_watcher() to
 # see why
 #
-def _timestamp(ssid):
+def _timestamp(emgr_sid):
 
     with ts_lock:
         now = time.time()
-        os.system('echo "%s" > %s/%s/timestamp' % (now, root, ssid))
+        os.system('echo "%s" > %s/%s/timestamp' % (now, root, emgr_sid))
 
 
 # ------------------------------------------------------------------------------
 #
-def _get_timestamp(ssid):
+def _get_timestamp(emgr_sid):
 
     with ts_lock:
-        with open("%s/%s/timestamp" % (root, ssid), "r") as f:
+        with open("%s/%s/timestamp" % (root, emgr_sid), "r") as f:
             return float(f.read().strip())
 
 
@@ -117,25 +117,25 @@ def _state_cb(unit, state):
 
     unit_d = unit.as_dict()
 
-    # we dig the ssid and stid out of the unit name
+    # we dig the emgr_sid and emgr_tid out of the unit name
     if not unit_d['name'] or not ':' in unit_d['name']:
         print "state_cb: invalid units name: %s" % unit_d['name']
         return True
 
-    ssid, stid = unit_d['name'].split(':', 1)
+    emgr_sid, emgr_tid = unit_d['name'].split(':', 1)
 
     with session_lock:
 
-        if not ssid in sessions:
-            print "state_cb: invalid session id: %s" % ssid
+        if not emgr_sid in sessions:
+            print "state_cb: invalid session id: %s" % emgr_sid
             return True
 
-        if not stid in sessions[ssid]['tasks']:
-            print "state_cb: invalid task id: %s" % stid
+        if not emgr_tid in sessions[emgr_sid]['tasks']:
+            print "state_cb: invalid task id: %s" % emgr_tid
             return True
 
-        print 'state_cb: updating task state: %s:%s : %s' % (ssid, stid, state)
-        sessions[ssid]['tasks'][stid]['state'] = state
+        print 'state_cb: updating task state: %s:%s : %s' % (emgr_sid, emgr_tid, state)
+        sessions[emgr_sid]['tasks'][emgr_tid]['state'] = state
         return True
 
 
@@ -143,29 +143,29 @@ def _state_cb(unit, state):
 #
 # run a (partial) workload
 #
-def _run_workload(ssid):
+def _run_workload(emgr_sid):
 
     try:
         with session_lock:
-            cwd = sessions[ssid]['cwd']
-            wld = sessions[ssid]['wld']
+            cwd = sessions[emgr_sid]['cwd']
+            wld = sessions[emgr_sid]['wld']
             if not os.path.exists(wld):
-                raise ValueError("swift session id %s is inconsistent" % ssid)
+                raise ValueError("swift session id %s is inconsistent" % emgr_sid)
 
             # we only need to do anything if there are tasks to be executed
             task_files = glob.glob("%s/*.json" % wld)
             if not task_files:
-                print "no tasks to execute for session %s (refreshing timestamp)" % ssid
-                _timestamp(ssid)
+                print "no tasks to execute for session %s (refreshing timestamp)" % emgr_sid
+                _timestamp(emgr_sid)
                 return None
 
             # avoid rerunning units on the next timeout, by creating a new workload
             # dir for new units, and re-linking the 'workload' link to that one
-            old_wl_name = 'workload_%d' % sessions[ssid]['wlcnt']
-            sessions[ssid]['wlcnt'] += 1
-            new_wl_name = 'workload_%d' % sessions[ssid]['wlcnt']
+            old_wl_name = 'workload_%d' % sessions[emgr_sid]['wlcnt']
+            sessions[emgr_sid]['wlcnt'] += 1
+            new_wl_name = 'workload_%d' % sessions[emgr_sid]['wlcnt']
 
-            mkdir ('%s/%s/%s' % (root, ssid, new_wl_name))
+            mkdir ('%s/%s/%s' % (root, emgr_sid, new_wl_name))
             unlink(cwd, 'workload')
             link  (cwd, new_wl_name, 'workload')
 
@@ -234,17 +234,17 @@ def _run_workload(ssid):
         def _wl_executor(cfg, run, sw):
             # run the workload, and also pass the state callback so that we get
             # state notifications
-            sid = aimes.emgr.execute_swift_workload(cfg, run, sw, _state_cb)
-            with open("%s/%s/session_ids.txt" % (data, ssid), "a") as f:
-                f.write("%s\n" % sid)
-            mkdir("%s/%s/%s/" % (data, ssid, sid))
-            ru.write_json(run,  "%s/%s/%s/run.json"  % (data, ssid, sid))
-            ru.write_json(cfg,  "%s/%s/%s/cfg.json"  % (data, ssid, sid))
-            ru.write_json(work, "%s/%s/%s/work.json" % (data, ssid, sid))
+            rp_sid = aimes.emgr.execute_swift_workload(cfg, run, sw, _state_cb)
+            with open("%s/%s/session_ids.txt" % (data, emgr_sid), "a") as f:
+                f.write("%s\n" % rp_sid)
+            mkdir("%s/%s/%s/" % (data, emgr_sid, rp_sid))
+            ru.write_json(run,  "%s/%s/%s/run.json"  % (data, emgr_sid, rp_sid))
+            ru.write_json(cfg,  "%s/%s/%s/cfg.json"  % (data, emgr_sid, rp_sid))
+            ru.write_json(work, "%s/%s/%s/work.json" % (data, emgr_sid, rp_sid))
 
         wl_thread = threading.Thread(target=_wl_executor, args=[cfg, run, sw])
         wl_thread.start()
-        sessions[ssid]['threads'].append(wl_thread)
+        sessions[emgr_sid]['threads'].append(wl_thread)
 
         # remove the timestamp -- no need to watch this workload until new units
         # arrive
@@ -276,243 +276,243 @@ def swift_session_list():
 @bottle.route('/swift/sessions/', method='PUT')
 def swift_session_create():
 
-    ssid = ru.generate_id(prefix="ssid.%(days)06d.%(day_counter)04d",
+    emgr_sid = ru.generate_id(prefix="emgr_sid.%(days)06d.%(day_counter)04d",
                           mode=ru.ID_CUSTOM)
 
-    if os.path.exists('%s/%s/' % (root, ssid)):
+    if os.path.exists('%s/%s/' % (root, emgr_sid)):
         return {"success" : False,
-                "ssid"    : ssid,
-                "error"   : "swift session '%s' exists" % ssid}
+                "emgr_sid": emgr_sid,
+                "error"   : "swift session '%s' exists" % emgr_sid}
 
     with session_lock:
-        sessions[ssid]            = dict()
-        sessions[ssid]['tasks']   = dict()
-        sessions[ssid]['threads'] = list()  # active workload executions
-        sessions[ssid]['tcnt']    = 0       # counter for generating task IDs
-        sessions[ssid]['wlcnt']   = 0       # counter for generating workload IDs
-        sessions[ssid]['cwd']     = "%s/%s"          % (root, ssid)
-        sessions[ssid]['wld']     = "%s/%s/workload" % (root, ssid)
+        sessions[emgr_sid]            = dict()
+        sessions[emgr_sid]['tasks']   = dict()
+        sessions[emgr_sid]['threads'] = list()  # active workload executions
+        sessions[emgr_sid]['tcnt']    = 0       # counter for generating task IDs
+        sessions[emgr_sid]['wlcnt']   = 0       # counter for generating workload IDs
+        sessions[emgr_sid]['cwd']     = "%s/%s"          % (root, emgr_sid)
+        sessions[emgr_sid]['wld']     = "%s/%s/workload" % (root, emgr_sid)
 
         # create the first workload dir, and link 'workload' to it
-        cwd = sessions[ssid]['cwd']
-        wld = sessions[ssid]['wld']
-        wl_name = 'workload_%d'          % sessions[ssid]['wlcnt']
-        mkdir('%s/%s/%s' % (root, ssid, wl_name))
+        cwd = sessions[emgr_sid]['cwd']
+        wld = sessions[emgr_sid]['wld']
+        wl_name = 'workload_%d' % sessions[emgr_sid]['wlcnt']
+        mkdir('%s/%s/%s' % (root, emgr_sid, wl_name))
         link (cwd, wl_name, 'workload')
 
     return {"success" : True,
-            "ssid"    : ssid,
-            "result"  : "swift session '%s' has been created" % ssid}
+            "emgr_sid": emgr_sid,
+            "result"  : "swift session '%s' has been created" % emgr_sid}
 
 
 # ------------------------------------------------------------------------------
 # add a task to a swift workload
-@bottle.route('/swift/sessions/<ssid>', method='PUT')
-def swift_task_submit(ssid=None):
+@bottle.route('/swift/sessions/<emgr_sid>', method='PUT')
+def swift_task_submit(emgr_sid=None):
 
-    if not ssid:
+    if not emgr_sid:
         return {"success" : False,
-                "ssid"    : ssid,
-                "stid"    : None,
+                "emgr_sid": emgr_sid,
+                "emgr_tid": None,
                 "error"   : "missing swift session id"}
 
-    # look for in root/<ssid>/
-    if not ssid in sessions:
+    # look for in root/<emgr_sid>/
+    if not emgr_sid in sessions:
         return {"success" : False,
-                "ssid"    : ssid,
-                "stid"    : None,
-                "error"   : "swift session id %s does not exist" % ssid}
+                "emgr_sid": emgr_sid,
+                "emgr_tid": None,
+                "error"   : "swift session id %s does not exist" % emgr_sid}
 
-    wld = sessions[ssid]['wld']
+    wld = sessions[emgr_sid]['wld']
     if not os.path.exists(wld):
         return {"success" : False,
-                "ssid"    : ssid,
-                "stid"    : None,
-                "error"   : "swift session %s is inconsistent" % ssid}
+                "emgr_sid": emgr_sid,
+                "emgr_tid": None,
+                "error"   : "swift session %s is inconsistent" % emgr_sid}
 
     td = json.loads(bottle.request.forms.get("td"))
 
     if not td:
         return {"success" : False,
-                "ssid"    : ssid,
-                "stid"    : None,
+                "emgr_sid": emgr_sid,
+                "emgr_tid": None,
                 "error"   : "missing task description"}
 
     with session_lock:
-        stid  = 'task.%06d' % sessions[ssid]['tcnt']
-        sessions[ssid]['tcnt'] += 1
+        emgr_tid = 'task.%06d' % sessions[emgr_sid]['tcnt']
+        sessions[emgr_sid]['tcnt'] += 1
 
         # we set the swift task id as CU name, so that we can identify the ytask
         # later, when getting RP state updates
-        td['name'] = "%s:%s" % (ssid, stid)
+        td['name'] = "%s:%s" % (emgr_sid, emgr_tid)
 
-        fname = '%s/%s.json' % (wld, stid)
+        fname = '%s/%s.json' % (wld, emgr_tid)
         ru.write_json(td, fname)
-        sessions[ssid]['tasks'][stid] = dict()
-        sessions[ssid]['tasks'][stid]['td']      = td
-        sessions[ssid]['tasks'][stid]['state']   = 'New'
-        sessions[ssid]['tasks'][stid]['created'] = time.time()
+        sessions[emgr_sid]['tasks'][emgr_tid] = dict()
+        sessions[emgr_sid]['tasks'][emgr_tid]['td']      = td
+        sessions[emgr_sid]['tasks'][emgr_tid]['state']   = 'New'
+        sessions[emgr_sid]['tasks'][emgr_tid]['created'] = time.time()
 
-        _timestamp(ssid)
+        _timestamp(emgr_sid)
 
     return {"success" : True,
-            "ssid"    : ssid,
-            "stid"    : stid,
-            "result"  : "task '%s' created for swift session %s" % (stid, ssid)}
+            "emgr_sid": emgr_sid,
+            "emgr_tid": emgr_tid,
+            "result"  : "task '%s' created for swift session %s" % (emgr_tid, emgr_sid)}
 
 
 # ------------------------------------------------------------------------------
 # list currently defined units in the session
-@bottle.route('/swift/sessions/<ssid>', method='GET')
-def swift_session_list(ssid=None):
+@bottle.route('/swift/sessions/<emgr_sid>', method='GET')
+def swift_session_list(emgr_sid=None):
 
-    if not ssid:
+    if not emgr_sid:
         return {"success" : False,
-                "ssid"    : ssid,
+                "emgr_sid": emgr_sid,
                 "error"   : "missing swift session id"}
 
-    # look for in root/<ssid>/
-    if not ssid in sessions:
+    # look for in root/<emgr_sid>/
+    if not emgr_sid in sessions:
         return {"success" : False,
-                "ssid"    : ssid,
-                "error"   : "swift session id %s does not exist" % ssid}
+                "emgr_sid": emgr_sid,
+                "error"   : "swift session id %s does not exist" % emgr_sid}
 
-    wld = sessions[ssid]['wld']
+    wld = sessions[emgr_sid]['wld']
     if not os.path.exists(wld):
         return {"success" : False,
-                "ssid"    : ssid,
-                "error"   : "swift session %s is inconsistent" % ssid}
+                "emgr_sid": emgr_sid,
+                "error"   : "swift session %s is inconsistent" % emgr_sid}
 
     ret = dict()
     ret['tasks'] = dict()
-    for t in sessions[ssid]['tasks']:
+    for t in sessions[emgr_sid]['tasks']:
         ret['tasks'][t] = dict()
-        ret['tasks'][t]['state'] = sessions[ssid]['tasks'][t]['state']
+        ret['tasks'][t]['state'] = sessions[emgr_sid]['tasks'][t]['state']
 
     bottle.response.content_type = 'application/json'
     return {"success" : True,
-            "ssid"    : ssid,
+            "emgr_sid": emgr_sid,
             "result"  : ret}
 
 
 # ------------------------------------------------------------------------------
 # inspect a single task
-@bottle.route('/swift/sessions/<ssid>/<stid>', method='GET')
-def swift_task_state(ssid=None, stid=None):
+@bottle.route('/swift/sessions/<emgr_sid>/<emgr_tid>', method='GET')
+def swift_task_state(emgr_sid=None, emgr_tid=None):
 
-    if not ssid:
+    if not emgr_sid:
         return {"success" : False,
-                "ssid"    : ssid,
-                "stid"    : None,
+                "emgr_sid": emgr_sid,
+                "emgr_tid": None,
                 "error"   : "missing swift session id"}
 
-    if not stid:
+    if not emgr_tid:
         return {"success" : False,
-                "ssid"    : ssid,
-                "stid"    : stid,
+                "emgr_sid": emgr_sid,
+                "emgr_tid": emgr_tid,
                 "error"   : "missing swift task id"}
 
-    if not ssid in sessions:
+    if not emgr_sid in sessions:
         return {"success" : False,
-                "ssid"    : ssid,
-                "error"   : "swift session id %s does not exist" % ssid}
+                "emgr_sid": emgr_sid,
+                "error"   : "swift session id %s does not exist" % emgr_sid}
 
-    if not stid in sessions[ssid]['tasks']:
+    if not emgr_tid in sessions[emgr_sid]['tasks']:
         return {"success" : False,
-                "ssid"    : ssid,
-                "ssid"    : stid,
-                "error"   : "swift task id %s does not exist in session %s" % (stid, ssid)}
+                "emgr_sid": emgr_sid,
+                "emgr_sid": emgr_tid,
+                "error"   : "swift task id %s does not exist in session %s" % (emgr_tid, emgr_sid)}
 
 
     with session_lock:
-        ret = sessions[ssid]['tasks'][stid]
+        ret = sessions[emgr_sid]['tasks'][emgr_tid]
 
 
     bottle.response.content_type = 'application/json'
     return {"success" : True,
-            "ssid"    : ssid,
-            "stid"    : stid,
+            "emgr_sid": emgr_sid,
+            "emgr_tid": emgr_tid,
             "result"  : ret}
 
 
 # ------------------------------------------------------------------------------
 # inspect a single task
-@bottle.route('/swift/sessions/<ssid>/<stid>', method='DELETE')
-def swift_task_cancel(ssid=None, stid=None):
+@bottle.route('/swift/sessions/<emgr_sid>/<emgr_tid>', method='DELETE')
+def swift_task_cancel(emgr_sid=None, emgr_tid=None):
 
     # note that this currently only deletes all knowledge about a task, but does
     # not actually attempt to cancel the task instance
 
-    if not ssid:
+    if not emgr_sid:
         return {"success" : False,
-                "ssid"    : ssid,
-                "stid"    : None,
+                "emgr_sid": emgr_sid,
+                "emgr_tid": None,
                 "error"   : "missing swift session id"}
 
-    if not stid:
+    if not emgr_tid:
         return {"success" : False,
-                "ssid"    : ssid,
-                "stid"    : stid,
+                "emgr_sid": emgr_sid,
+                "emgr_tid": emgr_tid,
                 "error"   : "missing swift task id"}
 
-    if not ssid in sessions:
+    if not emgr_sid in sessions:
         return {"success" : False,
-                "ssid"    : ssid,
-                "error"   : "swift session id %s does not exist" % ssid}
+                "emgr_sid": emgr_sid,
+                "error"   : "swift session id %s does not exist" % emgr_sid}
 
-    if not stid in sessions[ssid]['tasks']:
+    if not emgr_tid in sessions[emgr_sid]['tasks']:
         return {"success" : False,
-                "ssid"    : ssid,
-                "ssid"    : stid,
-                "error"   : "swift task id %s does not exist in session %s" % (stid, ssid)}
+                "emgr_sid": emgr_sid,
+                "emgr_sid": emgr_tid,
+                "error"   : "swift task id %s does not exist in session %s" % (emgr_tid, emgr_sid)}
 
 
     with session_lock:
-        del(sessions[ssid]['tasks'][stid])
+        del(sessions[emgr_sid]['tasks'][emgr_tid])
 
 
     bottle.response.content_type = 'application/json'
     return {"success" : True,
-            "ssid"    : ssid,
-            "stid"    : stid,
-            "result"  : "Task %s in session %s deleted" % (stid, ssid)}
+            "emgr_sid": emgr_sid,
+            "emgr_tid": emgr_tid,
+            "result"  : "Task %s in session %s deleted" % (emgr_tid, emgr_sid)}
 
 
 # ------------------------------------------------------------------------------
 #
 # delete a specific workload
 #
-@bottle.route('/swift/sessions/<ssid>', method='DELETE' )
-def swift_session_delete(ssid=None):
+@bottle.route('/swift/sessions/<emgr_sid>', method='DELETE' )
+def swift_session_delete(emgr_sid=None):
 
     # note that this will not cancel any tasks
 
-    if not ssid:
+    if not emgr_sid:
         return {"success" : False,
-                "ssid"    : ssid,
+                "emgr_sid": emgr_sid,
                 "error"   : "missing swift session id"}
 
-    # look for in root/<ssid>/
-    if not ssid in sessions:
+    # look for in root/<emgr_sid>/
+    if not emgr_sid in sessions:
         return {"success" : False,
-                "ssid"    : ssid,
-                "error"   : "swift session id %s does not exist" % ssid}
+                "emgr_sid": emgr_sid,
+                "error"   : "swift session id %s does not exist" % emgr_sid}
 
-    wld = sessions[ssid]['wld']
+    wld = sessions[emgr_sid]['wld']
     if not os.path.exists(wld):
         return {"success" : False,
-                "ssid"    : ssid,
-                "error"   : "swift session %s is inconsistent" % ssid}
+                "emgr_sid": emgr_sid,
+                "error"   : "swift session %s is inconsistent" % emgr_sid}
 
 
     with session_lock:
-        del(sessions[ssid])
-        os.system('rm -rf %s/%s' % (root, ssid))
+        del(sessions[emgr_sid])
+        os.system('rm -rf %s/%s' % (root, emgr_sid))
 
 
     return {"success" : True,
-            "ssid"    : ssid,
-            "result"  : "workload %s deleted" % ssid}
+            "emgr_sid": emgr_sid,
+            "result"  : "workload %s deleted" % emgr_sid}
 
 
 # ------------------------------------------------------------------------------
@@ -532,29 +532,29 @@ def _workload_watcher(terminate):
 
     while not terminate.is_set():
 
-        for ssid in sessions:
+        for emgr_sid in sessions:
 
-          # print "timed workload check for %s" % ssid
+          # print "timed workload check for %s" % emgr_sid
 
-            ts_file = "%s/%s/timestamp" % (root, ssid)
+            ts_file = "%s/%s/timestamp" % (root, emgr_sid)
 
             if not os.path.exists(ts_file):
                 # workload does not need any watching
                 continue
 
             # check if enough time passed -- if not, nothing to do
-            last_action = _get_timestamp(ssid)
+            last_action = _get_timestamp(emgr_sid)
             if (time.time() - last_action) < timeout:
                 print "timed workload check for %s skipped (%.2f < %.2f)" \
-                        % (ssid, (time.time() - last_action), timeout)
+                        % (emgr_sid, (time.time() - last_action), timeout)
                 continue
 
             # we should run this workload
             try:
-                print "timed workload run for %s" % ssid
-                _run_workload(ssid)
+                print "timed workload run for %s" % emgr_sid
+                _run_workload(emgr_sid)
             except Exception as e:
-                print "error on timed workload run for %s: %s" % (ssid, e)
+                print "error on timed workload run for %s: %s" % (emgr_sid, e)
 
         # avoid busy loop
         time.sleep(1)
@@ -584,16 +584,16 @@ def _workload_executor(terminate):
 
         with session_lock:
 
-            for ssid in sessions:
+            for emgr_sid in sessions:
 
-                for stid in sessions[ssid]['tasks']:
+                for emgr_tid in sessions[emgr_sid]['tasks']:
 
-                    created = sessions[ssid]['tasks'][stid]['created']
+                    created = sessions[emgr_sid]['tasks'][emgr_tid]['created']
 
                     if  now > (created + fake_ttc) and \
-                        sessions[ssid]['tasks'][stid]['state'] != 'Done':
-                        print 'updating task state: %s:%s : DONE' % (ssid, stid)
-                        sessions[ssid]['tasks'][stid]['state'] = 'Done'
+                        sessions[emgr_sid]['tasks'][emgr_tid]['state'] != 'Done':
+                        print 'updating task state: %s:%s : DONE' % (emgr_sid, emgr_tid)
+                        sessions[emgr_sid]['tasks'][emgr_tid]['state'] = 'Done'
 
         # avoid busy loop
         time.sleep(5)

--- a/bin/aimes-emgr-rest
+++ b/bin/aimes-emgr-rest
@@ -237,8 +237,8 @@ def _run_workload(emgr_sid):
             rp_sid = aimes.emgr.execute_swift_workload(cfg, run, sw, _state_cb)
 
             mkdir("%s/%s/%s/" % (data, emgr_sid, rp_sid))
-            ru.write_json(run,  "%s/%s/%s/run.json"  % (data, emgr_sid, rp_sid))
-            ru.write_json(cfg,  "%s/%s/%s/cfg.json"  % (data, emgr_sid, rp_sid))
+            ru.write_json(cfg, "%s/%s/%s/cfg.json"  % (data, emgr_sid, rp_sid))
+            ru.write_json(sw,  "%s/%s/%s/work.json" % (data, emgr_sid, rp_sid))
             with open("%s/%s/session_ids.txt" % (data, emgr_sid), "a+") as f:
                 f.write("%s\n" % rp_sid)
 

--- a/bin/aimes-emgr-rest
+++ b/bin/aimes-emgr-rest
@@ -57,12 +57,14 @@ import radical.utils as ru
 #
 config   = ru.read_json('%s/config.json' % os.path.dirname(__file__))
 root     = "%s/swift" % config["path"]
+data     = "%s/data"  % config["path"] # where to store session data
 timeout  = 5       # run workload after 10 seconds of idleness
 fake_ttc = 30      # seconds until a faked task execution is declared done
 sessions = dict()  # record running units
 
 # make sure the root exists
 os.system('mkdir -p %s' % root)
+os.system('mkdir -p %s' % data)
 
 # We lock two entities: timestamp and sessions
 ts_lock      = threading.RLock()
@@ -232,7 +234,13 @@ def _run_workload(ssid):
         def _wl_executor(cfg, run, sw):
             # run the workload, and also pass the state callback so that we get
             # state notifications
-            aimes.emgr.execute_swift_workload(cfg, run, sw, _state_cb)
+            sid = aimes.emgr.execute_swift_workload(cfg, run, sw, _state_cb)
+            with open("%s/session_ids.txt" % data, "a") as f:
+                f.write("%s\n" % sid)
+            mkdir("%s/%s/" % (data, sid))
+            ru.write_json(run,  "%s/%s/run.json"  % (data, sid))
+            ru.write_json(cfg,  "%s/%s/cfg.json"  % (data, sid))
+            ru.write_json(work, "%s/%s/work.json" % (data, sid))
 
         wl_thread = threading.Thread(target=_wl_executor, args=[cfg, run, sw])
         wl_thread.start()

--- a/bin/aimes-emgr-rest-experiments
+++ b/bin/aimes-emgr-rest-experiments
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+
+import os
+import glob
+
+import radical.utils as ru
+import radical.pilot as rp
+
+
+# This script will postprocess experiments running via the aimes-emgr-resr
+# interface.  We expect the following existing data layout:
+#
+#   -- data/
+#      |
+#      +-- emgr_sid/
+#          |
+#          +-- session_ids.txt
+#          +-- session_id_1/
+#          |   +-- cfg.json
+#          |   +-- work.json
+#          |
+#          +-- session_id_2/
+#          |   +-- cfg.json
+#          |   +-- work.json
+#          ...
+#
+# For any emgr_sid found in session_ids.txt, we check if any post processing has
+# been done before (existence of data/emgr_sid/fetch.ok).  If not, we perform the
+# following actions:
+#
+#   - for each rp_sid in session_ids
+#     - fetch session.json to data/emgr_sid/rp_sid/session.json
+#     - fetch profiles to same location
+#
+# We use the same configuration files as the aimes-emgr-rest server itself.
+#
+config   = ru.read_json('%s/config.json' % os.path.dirname(__file__))
+dburl    = config["mongodb"]
+root     = "%s/swift" % config["path"]
+data     = "%s/data"  % config["path"] # where to store session data
+
+# make sure the root exists
+os.system('mkdir -p %s' % root)
+os.system('mkdir -p %s' % data)
+
+# connect to mongodb
+_, db, dbname, _, _ = ru.mongodb_connect (dburl)
+
+
+# ------------------------------------------------------------------------------
+#
+def process_emgr_session(emgr_sid):
+    """
+    for each emgr_sid, we expect a data/emgr_sid dir to exist.  In there we expect
+    a session_ids.txt, and call 'process_rp_session' for each of the IDs in that
+    file.
+    """
+
+    print "  -- emgr sid: %s" % emgr_sid
+
+    if not os.path.isdir("%s/%s/" % (data, emgr_sid)):
+        raise ValueError("no emgr session dir for %s" % emgr_sid)
+
+    with open("%s/%s/session_ids.txt" % (data, emgr_sid), "r") as f:
+        lines = f.readlines()
+        rp_sids = [line.strip() for line in lines]
+
+    for rp_sid in rp_sids:
+        process_rp_session(emgr_sid, rp_sid)
+
+    # get data frames from json data
+    session_frame, pilot_frame, unit_frame = rp.utils.get_session_frames(rp_sids, db)
+
+    print session_frame
+    print pilot_frame
+    print unit_frame
+
+
+# ------------------------------------------------------------------------------
+#
+def process_rp_session(emgr_sid, rp_sid):
+
+    print "    -- rp sid: %s" % rp_sid,
+
+    if not os.path.isdir("%s/%s/%s/" % (data, emgr_sid, rp_sid)):
+        raise ValueError("no rp session dir for %s" % emgr_sid)
+
+    if os.path.isfile("%s/%s/%s/session.json" % (data, emgr_sid, rp_sid)):
+        print '...skip'
+
+    else:
+        # store session data as json
+        docs = rp.utils.get_session_docs(db, rp_sid)
+        ru.write_json(docs, "%s/%s/%s/session.json" % (data, emgr_sid, rp_sid))
+        print '...done'
+
+
+
+# ------------------------------------------------------------------------------
+#
+if __name__ == "__main__":
+
+    if not os.path.isdir("%s/" % data):
+        raise ValueError("no data dir at %s" % data)
+
+    emgr_sids = glob.glob("%s/*" % data)
+    for emgr_sid in emgr_sids:
+        process_emgr_session(emgr_sid.split('/')[-1])
+
+
+# ------------------------------------------------------------------------------
+

--- a/bin/conf/localhost.json
+++ b/bin/conf/localhost.json
@@ -1,0 +1,25 @@
+
+{
+    "cluster_bandwidth": {
+        "localhost": {
+            "54_196_51_239": {
+                "out": 26.0
+            }
+        }
+    },
+    "cluster_config": {
+        "": {
+            "num_nodes": 1024,
+            "queue_info": {
+                "normal": {
+                    "max_walltime"      : 172800,
+                    "num_procs_limit"   : 1024,
+                    "queue_name"        : "normal",
+                    "queued_jobs_limit" : 4
+                }
+            }
+        }
+    },
+    "cluster_list": ["localhost"]
+}
+

--- a/bin/config.json
+++ b/bin/config.json
@@ -42,22 +42,22 @@
             #//     "gordon.sdsc.xsede.org"     : "pbs"
             #// },
             "unsupported": {
-              # "supermic.cct-lsu.xsede.org": {
-              #     "sched": "pbs",
-              #     "fconf": "conf/xsede.supermic.json"
-              # },
-              # "comet.sdsc.xsede.org": {
-              #     "sched": "slurm",
-              #     "fconf": "conf/xsede.comet.json"
-              # },
-              # "gordon.sdsc.xsede.org": {
-              #     "sched": "pbs",
-              #     "fconf": "conf/xsede.gordon.json"
-              # }
-                "localhost": {
-                    "sched": "fork",
-                    "fconf": "conf/localhost.json"
-                }
+              "supermic.cct-lsu.xsede.org": {
+                  "sched": "pbs",
+                  "fconf": "conf/xsede.supermic.json"
+              },
+              "comet.sdsc.xsede.org": {
+                  "sched": "slurm",
+                  "fconf": "conf/xsede.comet.json"
+              },
+              "gordon.sdsc.xsede.org": {
+                  "sched": "pbs",
+                  "fconf": "conf/xsede.gordon.json"
+              }
+              #   "localhost": {
+              #      "sched": "fork",
+              #      "fconf": "conf/localhost.json"
+              #  }
             }
         }
     },

--- a/bin/config.json
+++ b/bin/config.json
@@ -42,17 +42,21 @@
             #//     "gordon.sdsc.xsede.org"     : "pbs"
             #// },
             "unsupported": {
-                "supermic.cct-lsu.xsede.org": {
-                    "sched": "pbs",
-                    "fconf": "conf/xsede.supermic.json"
-                },
-                "comet.sdsc.xsede.org": {
-                    "sched": "slurm",
-                    "fconf": "conf/xsede.comet.json"
-                },
-                "gordon.sdsc.xsede.org": {
-                    "sched": "pbs",
-                    "fconf": "conf/xsede.gordon.json"
+              # "supermic.cct-lsu.xsede.org": {
+              #     "sched": "pbs",
+              #     "fconf": "conf/xsede.supermic.json"
+              # },
+              # "comet.sdsc.xsede.org": {
+              #     "sched": "slurm",
+              #     "fconf": "conf/xsede.comet.json"
+              # },
+              # "gordon.sdsc.xsede.org": {
+              #     "sched": "pbs",
+              #     "fconf": "conf/xsede.gordon.json"
+              # }
+                "localhost": {
+                    "sched": "fork",
+                    "fconf": "conf/localhost.json"
                 }
             }
         }

--- a/examples/aimes-swift-example.py
+++ b/examples/aimes-swift-example.py
@@ -31,32 +31,32 @@ def list_sessions():
 def create_session():
     r = requests.put("%s/swift/sessions/" % ep)
     print r.json()
-    ssid = r.json()['ssid']
-    print ssid
-    return ssid
+    emgr_sid = r.json()['emgr_sid']
+    print emgr_sid
+    return emgr_sid
 
 
-def add_task(ssid):
+def add_task(emgr_sid):
     global cnt
     cnt += 1
     cud = {"executable" : "/bin/sleep",
            "arguments"  : ["%d" % cnt],
            "cores"      : 1}
     data = {'td': json.dumps(cud)}
-    r = requests.put("%s/swift/sessions/%s" % (ep, ssid), data)
+    r = requests.put("%s/swift/sessions/%s" % (ep, emgr_sid), data)
     print r.json()
-    return r.json()['stid']
+    return r.json()['emgr_tid']
 
 
-def dump_session(ssid):
-    r = requests.get("%s/swift/sessions/%s" % (ep, ssid))
+def dump_session(emgr_sid):
+    r = requests.get("%s/swift/sessions/%s" % (ep, emgr_sid))
     pprint.pprint(r.json())
 
 
-def check_task(ssid, stid):
-    r = requests.get("%s/swift/sessions/%s/%s" % (ep, ssid, stid))
+def check_task(emgr_sid, emgr_tid):
+    r = requests.get("%s/swift/sessions/%s/%s" % (ep, emgr_sid, emgr_tid))
   # pprint.pprint(r.json())
-    print 'task %s: %s' % (stid, r.json()['result']['state'])
+    print 'task %s: %s' % (emgr_tid, r.json()['result']['state'])
 
     if r.json()['result']['state'].lower() in ['done', 'canceled', 'failed']:
         return True
@@ -64,29 +64,29 @@ def check_task(ssid, stid):
         return False
 
 
-def run_session(ssid):
-    r = requests.put("%s/swift/sessions/%s/execute" % (ep, ssid))
+def run_session(emgr_sid):
+    r = requests.put("%s/swift/sessions/%s/execute" % (ep, emgr_sid))
     print r.json()
 
 
-def delete_session(ssid):
-    r = requests.delete("%s/swift/sessions/%s" % (ep, ssid))
+def delete_session(emgr_sid):
+    r = requests.delete("%s/swift/sessions/%s" % (ep, emgr_sid))
     print r.json()
 
 
 # create a session, and begin submitting tasks.  Then let some time expire so
 # that the tasks get executed by the watcher
 print ' ---------- create session'
-ssid = create_session()
+emgr_sid = create_session()
 
 print ' ---------- list sessions'
 list_sessions()
 tids = list()
 
 print ' ---------- submit tasks'
-tids.append(add_task(ssid))
-tids.append(add_task(ssid))
-tids.append(add_task(ssid))
+tids.append(add_task(emgr_sid))
+tids.append(add_task(emgr_sid))
+tids.append(add_task(emgr_sid))
 
 print ' ---------- sleep'
 time.sleep(6)
@@ -94,16 +94,16 @@ time.sleep(6)
 # Now we do the same again, and this batch should get executed in some seconds,
 # too.
 print ' ---------- submit tasks'
-tids.append(add_task(ssid))
-tids.append(add_task(ssid))
-tids.append(add_task(ssid))
+tids.append(add_task(emgr_sid))
+tids.append(add_task(emgr_sid))
+tids.append(add_task(emgr_sid))
 
 while True:
 
     # we wait for all tasks to finish
     all_finished = True
     for tid in tids:
-        if not check_task(ssid, tid):
+        if not check_task(emgr_sid, tid):
             all_finished = False
     if all_finished:
         break
@@ -114,9 +114,9 @@ while True:
 print ' ---------- all tasks are final'
 print ' ---------- list sessions, dump this session'
 list_sessions()
-dump_session(ssid)
+dump_session(emgr_sid)
 
 # print ' ---------- delete this session, list sessions'
-# delete_session(ssid)
+# delete_session(emgr_sid)
 # list_sessions()
 

--- a/setup.py
+++ b/setup.py
@@ -181,6 +181,8 @@ setup_args = {
     'install_requires'   : ['radical.pilot',
                             'aimes.skeleton',
                             'aimes.bundle',
+                            'bottle',
+                            'requests'
                            ],
     'tests_require'      : [],
     'test_suite'         : 'aimes.emgr.tests',

--- a/src/aimes/emgr/emgr.py
+++ b/src/aimes/emgr/emgr.py
@@ -1573,6 +1573,7 @@ def execute_swift_workload(cfg, run, swift_workload, swift_cb=None):
   # return 'wohoo!'
 
     session = None
+    sid     = None
 
     try:
 
@@ -1699,11 +1700,14 @@ def execute_swift_workload(cfg, run, swift_workload, swift_cb=None):
         # always clean up the session, no matter whether we caught an
         # exception
         record_run_state(run)
+        sid = session.uid
         if session:
             session.close(cleanup=False, terminate=True)
 
         if 'email' in cfg['log']['media']:
             email_report(cfg, run)
+
+    return sid
 
 
 # -----------------------------------------------------------------------------

--- a/src/aimes/emgr/emgr.py
+++ b/src/aimes/emgr/emgr.py
@@ -676,7 +676,7 @@ def derive_pilot_descriptions(cfg, strategy):
 
         pdesc = rp.ComputePilotDescription()
 
-        pdesc.project  = cfg['project_ids'][resource]
+        pdesc.project  = cfg['project_ids'].get(resource)
         pdesc.resource = resource  # label
 
         # Select a specific queue for hopper. This will become another
@@ -1245,7 +1245,8 @@ def uri_to_tag(resource):
     '''Pass.
     '''
 
-    tag = {'blacklight.psc.xsede.org'  : 'xsede.blacklight',
+    tag = {'localhost'                 : 'local.localhost',
+           'blacklight.psc.xsede.org'  : 'xsede.blacklight',
            'gordon.sdsc.xsede.org'     : 'xsede.gordon',
            'stampede.tacc.utexas.edu'  : 'xsede.stampede',
            'stampede.tacc.xsede.org'   : 'xsede.stampede',


### PR DESCRIPTION
This would be the first part: for each workload running via aimes.emgr, we return the session ID, and then create a session data dir to store cfg, run and workload as json files. We also store the session ID itself for later fetches of session json and profiles.
